### PR TITLE
Some Linux build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ lib*.a
 /src/tools/linux/symupload/sym_upload
 /src/tools/mac/dump_syms/dump_syms
 /src/tools/mac/dump_syms/dump_syms_mac
+/src/tools/windows/dump_syms_dwarf/dump_syms
 
 # Ignore unit test artifacts.
 *_unittest

--- a/src/client/linux/handler/minidump_descriptor.h
+++ b/src/client/linux/handler/minidump_descriptor.h
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <cstdint>
 
 #include "client/linux/handler/microdump_extra_info.h"
 #include "common/using_std_string.h"

--- a/src/processor/exploitability_linux.cc
+++ b/src/processor/exploitability_linux.cc
@@ -516,7 +516,6 @@ bool ExploitabilityLinux::DisassembleBytes(const string &architecture,
            raw_bytes_tmpfile);
   FILE *objdump_fp = popen(cmd, "r");
   if (!objdump_fp) {
-    fclose(objdump_fp);
     unlink(raw_bytes_tmpfile);
     BPLOG(ERROR) << "Failed to call objdump.";
     return false;


### PR DESCRIPTION
- **Fix Linux build by including cstdint to declare uintptr_t**

Fixes:

```
./src/client/linux/handler/minidump_descriptor.h:115:3: error: ‘uintptr_t’ does not name a type
  115 |   uintptr_t address_within_principal_mapping() const {
      |   ^~~~~~~~~
./src/client/linux/handler/minidump_descriptor.h:40:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```

- **Fix Linux build by not closing a null pointer**

Fixes:

```
src/processor/exploitability_linux.cc: In static member function ‘static bool google_breakpad::ExploitabilityLinux::DisassembleBytes(const std::string&, const uint8_t*, unsigned int, char*)’:
src/processor/exploitability_linux.cc:519:11: error: argument 1 null where non-null expected [-Werror=nonnull]
  519 |     fclose(objdump_fp);
      |     ~~~~~~^~~~~~~~~~~~
In file included from /usr/include/c++/13/cstdio:42,
                 from /usr/include/c++/13/ext/string_conversions.h:45,
                 from /usr/include/c++/13/bits/basic_string.h:4097,
                 from /usr/include/c++/13/string:54,
                 from /usr/include/c++/13/bits/locale_classes.h:40,
                 from /usr/include/c++/13/bits/ios_base.h:41,
                 from /usr/include/c++/13/ios:44,
                 from /usr/include/c++/13/ostream:40,
                 from /usr/include/c++/13/iostream:41,
                 from ./src/google_breakpad/processor/minidump.h:88,
                 from ./src/google_breakpad/processor/exploitability.h:44,
                 from ./src/processor/exploitability_linux.h:41,
                 from src/processor/exploitability_linux.cc:37:
/usr/include/stdio.h:183:12: note: in a call to function ‘int fclose(FILE*)’ declared ‘nonnull’
  183 | extern int fclose (FILE *__stream) __nonnull ((1));
      |
```