### PR TITLE
Fix autotools install by renaming MinGW dump_syms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ lib*.a
 /src/tools/linux/symupload/sym_upload
 /src/tools/mac/dump_syms/dump_syms
 /src/tools/mac/dump_syms/dump_syms_mac
-/src/tools/windows/dump_syms_dwarf/dump_syms
+/src/tools/windows/dump_syms_dwarf/dump_syms_dwarf
 
 # Ignore unit test artifacts.
 *_unittest

--- a/Makefile.am
+++ b/Makefile.am
@@ -388,7 +388,7 @@ endif LINUX_HOST
 
 if !DISABLE_TOOLS
 bin_PROGRAMS += \
-	src/tools/windows/dump_syms_dwarf/dump_syms
+	src/tools/windows/dump_syms_dwarf/dump_syms_dwarf
 endif
 
 if MINGW_HOST
@@ -839,7 +839,7 @@ src_tools_linux_md2core_minidump_2_core_unittest_LDADD = \
 endif LINUX_HOST
 
 if !DISABLE_TOOLS
-src_tools_windows_dump_syms_dwarf_dump_syms_SOURCES = \
+src_tools_windows_dump_syms_dwarf_dump_syms_dwarf_SOURCES = \
 	src/common/dwarf_cfi_to_module.cc \
 	src/common/dwarf_cu_to_module.cc \
 	src/common/dwarf_line_to_module.cc \
@@ -853,7 +853,7 @@ src_tools_windows_dump_syms_dwarf_dump_syms_SOURCES = \
 	src/common/pecoff/pecoffutils.cc \
 	src/common/pecoff/pecoff_file_id.cc \
 	src/tools/windows/dump_syms_dwarf/dump_syms.cc
-src_tools_windows_dump_syms_dwarf_dump_syms_LDADD = \
+src_tools_windows_dump_syms_dwarf_dump_syms_dwarf_LDADD = \
 	$(SOCKET_LIBS)
 endif
 

--- a/symbolize.py
+++ b/symbolize.py
@@ -5,9 +5,10 @@ import os
 import subprocess
 
 
+# Assumes in-source build. TODO: make it work with install?
 def dump_syms_path(bin):
     if bin.endswith(".exe"): # Windows target
-        ds_path = "src/tools/windows/dump_syms_dwarf/dump_syms"
+        ds_path = "src/tools/windows/dump_syms_dwarf/dump_syms_dwarf"
     else: # Linux or NaCl target
         ds_path = "src/tools/linux/dump_syms/dump_syms"
     return os.path.join(os.path.dirname(__file__), ds_path)


### PR DESCRIPTION
Rename the Windows symbol dumper dump_syms -> dump_syms_dwarf so that it doesn't clash with the ELF dump_syms, thus making it possible to run `make install`.

Note: this will require a release scripts change.