### PR TITLE
dwarf2reader: support NaCl Saigo CFA pseudo-register -2

### DIFF
--- a/src/common/dwarf/dwarf2reader.cc
+++ b/src/common/dwarf/dwarf2reader.cc
@@ -2277,6 +2277,9 @@ bool CallFrameInfo::State::ParseOperands(const char* format,
         operands->register_number = reader_->ReadUnsignedLEB128(cursor_, &len);
         if (len > bytes_left) return ReportIncomplete();
         cursor_ += len;
+        if (static_cast<int32_t>(operands->register_number) == Handler::kNaClCFARegister) {
+          operands->register_number = Handler::kCFARegister;
+        }
         break;
 
       case 'o':

--- a/src/common/dwarf/dwarf2reader.h
+++ b/src/common/dwarf/dwarf2reader.h
@@ -1235,7 +1235,11 @@ class CallFrameInfo {
 class CallFrameInfo::Handler {
  public:
   // The pseudo-register number for the canonical frame address.
-  enum { kCFARegister = -1 };
+  enum {
+    kCFARegister = -1,
+    kNaClCFARegister = -2,
+  };
+
 
   Handler() { }
   virtual ~Handler() { }


### PR DESCRIPTION
Saigo LLVM emits DWARF CFI using register number -2 as a pseudo-register when describing the canonical frame address.

Breakpad currently interprets this value as register 4294967294, which can produce invalid CFI rules and cause failures while processing symbols.

Normalize the NaCl CFA pseudo-register to Breakpad's existing kCFARegister representation when parsing CFI operands.

---

Disclaimer: Like for the PHDR NaCl thing (https://github.com/DaemonEngine/native_client/pull/6), I experimented using ChatGPT as a debugger assistant, providing the bot some diagnostic information in a discussion: `gdb` backtrace, output from `readelf`, `llvm-dwarfdump`, etc. The bot suggested me some diagnostics in order to figure out where the unexpected value was emitted. And after extensive testing of the build pipeline it turns out the problem got pretty well cornered!

After such investigation has been done, I decided to patch breakpad because modifying LLVM would probably be a nightmare, and this seems to be the least intrusive workaround.